### PR TITLE
Fixed Bug in OpenInNewTab

### DIFF
--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -59,7 +59,11 @@
 
     <!-- JavaScript function to show full-size image -->
     <script>
+        // Store Last Url for new tab opening
+        lastImageUrl = '';
+
         function showModal(imageUrl) {
+            lastImageUrl = imageUrl
             // Create a modal with the thumbnail image
             var modalHtml = '<div class="modal" tabindex="-1" role="dialog">' +
                                 '<div class="modal-dialog" role="document">' +
@@ -78,9 +82,8 @@
         }
 
         function openInNewTab() {
-            var fullSizeImage = document.getElementById('fullSizeImage');
-            if (fullSizeImage) {
-                window.open(fullSizeImage.src, '_blank');  // Open the full-size image URL in a new tab
+            if (lastImageUrl) {
+                window.open(lastImageUrl, '_blank');  // Open the full-size image URL in a new tab
             }
         }
     </script>


### PR DESCRIPTION
Fixed a Bug where a click on "Open in new Tab" Button may open the wrong image. The wrong image seems to be always the first image that was opened before.

This was because the img.src of the img.id="fullSizeImage" does not get overwritten but instead a new img does get generated each time.

This ist most likely because how bootstrap-modal works.

An update is provided wich does not use the img.src but stores the last ImageUrl globally and updates it accordingly.